### PR TITLE
Fix suffix variable name in entrypoint script

### DIFF
--- a/scripts/install-and-run-389ds.sh
+++ b/scripts/install-and-run-389ds.sh
@@ -5,7 +5,7 @@ export DIRSRV_HOSTNAME=${DIRSRV_HOSTNAME:-$(hostname --fqdn)}
 export DIRSRV_ADMIN_USERNAME=${DIRSRV_ADMIN_USERNAME:-"admin"}
 export DIRSRV_ADMIN_PASSWORD=${DIRSRV_ADMIN_PASSWORD:-${DIRSRV_MANAGER_PASSWORD:-"admin@123"}}
 export DIRSRV_MANAGER_PASSWORD=${DIRSRV_MANAGER_PASSWORD:-${DIRSRV_ADMIN_PASSWORD:-"admin@123"}}
-export DIRSRV_SUFFIX=${DIR_SUFFIX:-"dc=example,dc=com"}
+export DIRSRV_SUFFIX=${DIRSRV_SUFFIX:-"dc=example,dc=com"}
 
 BASEDIR="/etc/dirsrv/slapd-dir"
 ROOT_DN="cn=Directory Manager"


### PR DESCRIPTION
install-and-run-389ds.sh: take value from `DIRSRV_SUFFIX` env variable.